### PR TITLE
Specific version of a release stable.

### DIFF
--- a/waf/Dockerfile.multi
+++ b/waf/Dockerfile.multi
@@ -1,8 +1,12 @@
+ARG VERSION_MOD_SECURITY=3.0.0
+
 FROM ubuntu
 MAINTAINER blaize.net
 
+ARG VERSION_MOD_SECURITY
+
 COPY build.multi.sh /build.multi.sh
-RUN chmod +x /build.multi.sh && /bin/bash -c "source /build.multi.sh"
+RUN chmod +x /build.multi.sh && /bin/bash -c "source /build.multi.sh ${VERSION_MOD_SECURITY}"
 
 FROM ubuntu
 
@@ -11,7 +15,7 @@ COPY config.multi.sh /config.multi.sh
 COPY --from=0 /usr/src/modsecurity/ /usr/src/modsecurity/
 COPY --from=0 /usr/local/nginx/ /usr/local/nginx/
 
-RUN chmod +x /config.multi.sh && /bin/bash -c "source /config.multi.sh"
+RUN chmod +x /config.multi.sh && /bin/bash -c "source /config.multi.sh ${VERSION_MOD_SECURITY}"
 
 COPY nginx.conf /usr/local/nginx/conf/nginx.conf
 COPY modsec_includes.conf /usr/local/nginx/conf/modsec_includes.conf

--- a/waf/Dockerfile.single
+++ b/waf/Dockerfile.single
@@ -1,9 +1,13 @@
+ARG VERSION_MOD_SECURITY=3.0.0
+
 FROM ubuntu
 MAINTAINER blaize.net
 
+ARG VERSION_MOD_SECURITY
+
 ADD build.sh /build.sh
 RUN chmod +x /build.sh
-RUN /bin/bash -c "source /build.sh"
+RUN /bin/bash -c "source /build.sh ${VERSION_MOD_SECURITY}"
 
 ADD nginx.conf /usr/local/nginx/conf/nginx.conf
 ADD modsec_includes.conf /usr/local/nginx/conf/modsec_includes.conf

--- a/waf/build.multi.sh
+++ b/waf/build.multi.sh
@@ -1,11 +1,14 @@
 #!/bin/sh
+
+VERSION_MOD_SECURITY=$1
+
 #update and install dependencies
 apt-get update
 apt-get install -y git wget build-essential libpcre3 libpcre3-dev libssl-dev libtool autoconf apache2-dev libxml2-dev libcurl4-openssl-dev
 
 #make modsecurity
 cd /usr/src/
-git clone https://github.com/SpiderLabs/ModSecurity.git /usr/src/modsecurity
+git clone --depth 1 -b v${VERSION_MOD_SECURITY} --single-branch https://github.com/SpiderLabs/ModSecurity.git /usr/src/modsecurity
 cd /usr/src/modsecurity
 ./autogen.sh
 ./configure --enable-standalone-module --disable-mlogc

--- a/waf/build.sh
+++ b/waf/build.sh
@@ -1,11 +1,14 @@
 #!/bin/sh
 #update and install dependencies
+
+VERSION_MOD_SECURITY=$1
+
 apt-get update
 apt-get install -y git wget build-essential libpcre3 libpcre3-dev libssl-dev libtool autoconf apache2-dev libxml2-dev libcurl4-openssl-dev
 
 #make modsecurity
 cd /usr/src/
-git clone https://github.com/SpiderLabs/ModSecurity.git /usr/src/modsecurity
+git clone --depth 1 -b v${VERSION_MOD_SECURITY} --single-branch https://github.com/SpiderLabs/ModSecurity /usr/src/modsecurity
 cd /usr/src/modsecurity
 ./autogen.sh
 ./configure --enable-standalone-module --disable-mlogc

--- a/waf/config.multi.sh
+++ b/waf/config.multi.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+VERSION_MOD_SECURITY=$1
+
 #configure env
 ln -s /usr/local/nginx/sbin/nginx /bin/nginx
 cp /usr/src/modsecurity/unicode.mapping /usr/local/nginx/conf/
@@ -8,7 +10,7 @@ mkdir -p /opt/modsecurity/var/audit/
 #install signature
 apt-get update
 apt-get install -y git libpcre3 libpcre3-dev libssl-dev libtool autoconf apache2-dev libxml2-dev libcurl4-openssl-dev
-git clone https://github.com/SpiderLabs/owasp-modsecurity-crs.git /usr/src/owasp-modsecurity-crs
+git clone --depth 1 -b v${VERSION_MOD_SECURITY} --single-branch https://github.com/SpiderLabs/owasp-modsecurity-crs.git /usr/src/owasp-modsecurity-crs
 cp -R /usr/src/owasp-modsecurity-crs/rules/ /usr/local/nginx/conf/
 mv /usr/local/nginx/conf/rules/REQUEST-900-EXCLUSION-RULES-BEFORE-CRS.conf{.example,}
 mv /usr/local/nginx/conf/rules/RESPONSE-999-EXCLUSION-RULES-AFTER-CRS.conf{.example,}


### PR DESCRIPTION
**WHY ?**

> 2017: ModSecurity 3.0 released with support for NGINX and NGINX Plus

Stable security for a security purpose nginx security to better control access to feature for a specific version. 

**HOW ?**

* Call build with the specific version;
* get version on SH build script;
* Double ARG on Dockerfile like explain [here](https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact) on docker doc.

**NEED**

Tag it to v3 as it's a v3 mod security goal.